### PR TITLE
fix: make sure non-encoded text stays in the headers

### DIFF
--- a/spec/test-mime2.email
+++ b/spec/test-mime2.email
@@ -1,6 +1,6 @@
-From: =?UTF-8?q?=D0=A1=D0=BB=D1=83=D1=87=D0=B0=D0=B9=D0=BD=D1=8B=D0=B9?=
-  =?UTF-8?q?=D0=9F=D0=BE=D0=BB=D1=8C=D0=B7=D0=BE=D0=B2=D0=B0=D1=82=D0=B5=D0=BB=D1=8C?=
-  <random-user@example.com>
+From: =?UTF-8?q?=D0=A1=D0=BB=D1=83=D1=87=D0=B0=D0=B9=D0=BD=D1=8B=D0=B9=20?=
+  =?UTF-8?q?=D0=9F=D0=BE=D0=BB=D1=8C=D0=B7=D0=BE=D0=B2=D0=B0?=
+  =?UTF-8?q?=D1=82=D0=B5=D0=BB=D1=8C?= <random-user@example.com>
 To: admin@example.com
 Subject: Test email with weird multiline sender
 MIME-Version: 1.0

--- a/src/crystal-mime.cr
+++ b/src/crystal-mime.cr
@@ -38,7 +38,7 @@ module MIME
         if(last_key=="MISSING")
           puts "Unlikely that this is intended. Seeing line without a key:\n#{line}"
         end
-        headers[last_key] += " " + RFC2047.decode(line.lstrip()) # Append everything but the spaces
+        headers[last_key] += RFC2047.decode(line.lstrip()) # Append everything but the spaces
       elsif line.blank?
         break
       else

--- a/src/rfc2047.cr
+++ b/src/rfc2047.cr
@@ -29,7 +29,7 @@ module RFC2047
       else
         raise Unparseable.new(from)
       end
-      return text
+      text
     end
   end
 


### PR DESCRIPTION
Using `return` instead of `next` inside a block forces the decodong algorithm to quit early and skip the part of the string after the encoded part. Hence the email address is essentially lost.
In addition, the space should not be added between parts.