### PR TITLE
fix: correctly process quoted-printable bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ TODO: Write development instructions here
 ## Contributors
 
 - [Jonathan Siegel](https://github.com/usiegj00) - creator and maintainer
+- [Anton Karankevich](https://github.com/anton7c3) - some fixes from real use cases

--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,10 @@
 name: crystal-mime
-version: 0.1.17
+version: 0.1.18
 
 authors:
-  - Jonathan Siegel <usiegj00@gmail.com>
-  - Lex Siegel      <usiegl00@gmail.com>
+  - Jonathan Siegel   <usiegj00@gmail.com>
+  - Lex Siegel        <usiegl00@gmail.com>
+  - Anton Karankevich <anton_7c3@mail.ru>
 
 crystal: 1.7.2
 

--- a/spec/crystal-mime_spec.cr
+++ b/spec/crystal-mime_spec.cr
@@ -74,29 +74,50 @@ describe MIME do
     end
   end
 
-  describe "Parses email with multipart inside multipart" do
-    it "with multipart alternative inside mixed" do
-      f = {{ read_file("#{__DIR__}/test-mime-with-mixed-multipart.eml") }}
-      email = MIME.mail_object_from_raw(f)
-      expected_html_body = <<-PLAIN
-      <p>We see you&rsquo;re trying to create (or update) your XXX account. Use the following security code to verify your info. This code will only be valid for 20 minutes.</p>
-      <p>Your one-time security code: <span style="text-decoration: underline;"><strong>456748</strong></span></p>
-      <p><b>DO NOT SHARE.</b> Only enter it online.  Our reps will never ask for it.</p>
-      <p>If you didn&rsquo;t make this request, contact us immediately at 111-111-1113.</p>
-      <p>XXX</p>
-      PLAIN
-      expected_html_body = expected_html_body.gsub(/\r\n/, "\n").gsub(/\n/, "\r\n")
-      email.body_html.should eq expected_html_body
+  it "Parses email with multipart inside multipart" do
+    f = {{ read_file("#{__DIR__}/test-mime-with-mixed-multipart.eml") }}
+    email = MIME.mail_object_from_raw(f)
+    expected_html_body = <<-PLAIN
+    <p>We see you&rsquo;re trying to create (or update) your XXX account. Use the following security code to verify your info. This code will only be valid for 20 minutes.</p>
+    <p>Your one-time security code: <span style="text-decoration: underline;"><strong>456748</strong></span></p>
+    <p><b>DO NOT SHARE.</b> Only enter it online.  Our reps will never ask for it.</p>
+    <p>If you didn&rsquo;t make this request, contact us immediately at 111-111-1113.</p>
+    <p>XXX</p>
+    PLAIN
+    expected_html_body = expected_html_body.gsub(/\r\n/, "\n").gsub(/\n/, "\r\n")
+    email.body_html.should eq expected_html_body
 
-      expected_text_body = <<-PLAIN
-      We see you are trying to create (or update) your XXX account. Use the following security code to verify your info. This code will only be valid for 20 minutes.
-      Your one-time security code: 456748
-      DO NOT SHARE. Only enter it online.  Our reps will never ask for it.
-      If you didn&rsquo;t make this request, contact us immediately at 111-111-1113.
-      XXX
-      PLAIN
-      expected_text_body = expected_text_body.gsub(/\r\n/, "\n").gsub(/\n/, "\r\n")
-      email.body_text.should eq expected_text_body
-    end
+    expected_text_body = <<-PLAIN
+    We see you are trying to create (or update) your XXX account. Use the following security code to verify your info. This code will only be valid for 20 minutes.
+    Your one-time security code: 456748
+    DO NOT SHARE. Only enter it online.  Our reps will never ask for it.
+    If you didn&rsquo;t make this request, contact us immediately at 111-111-1113.
+    XXX
+    PLAIN
+    expected_text_body = expected_text_body.gsub(/\r\n/, "\n").gsub(/\n/, "\r\n")
+    email.body_text.should eq expected_text_body
+  end
+
+  it "parses email header with name and value on different lines" do
+    f = {{ read_file("#{__DIR__}/test-mime-header-on-2-lines.email") }}
+    email = MIME.mail_object_from_raw(f)
+    email.subject.should eq "Anti-spam test email"
+    email.headers["X-Antispam"].should eq "BCL:0;ARA:13230040|376014|69100299015|61400799027|7149299003|18002099003|56012099006|19003699004|16102099003|4076899003|8096899003;"
+  end
+
+  it "parses quoted printable body with trailing =" do
+    f = {{ read_file("#{__DIR__}/test-mime-with-trailing-equal-sign.email") }}
+    email = MIME.mail_object_from_raw(f)
+
+    expected_text_body = <<-PLAIN
+    Hello. I'm sending you the link to the form that you need to fill to complete the registration process.
+
+    http://example.com/form
+
+    Please make sure to fill the form before it expires. You only have 24 hours!
+
+    PLAIN
+
+    email.body_text.should eq expected_text_body
   end
 end

--- a/spec/test-mime-header-on-2-lines.email
+++ b/spec/test-mime-header-on-2-lines.email
@@ -1,0 +1,11 @@
+From: John Doe <johndoe@example.com>
+To: anna.smith@example.com
+Subject:
+  Anti-spam test email
+Content-Type: text/plain; charset=utf-8
+MIME-Version: 1.0
+X-Antispam:
+  BCL:0;ARA:13230040|376014|69100299015|61400799027|7149299003|18002099003|56012099006|19003699004|16102099003|4076899003|8096899003;
+
+This is a test email. Please do not reply on it.
+

--- a/spec/test-mime-with-trailing-equal-sign.email
+++ b/spec/test-mime-with-trailing-equal-sign.email
@@ -1,0 +1,16 @@
+From: =?UTF-8?q?=D0=A1=D0=BB=D1=83=D1=87=D0=B0=D0=B9=D0=BD=D1=8B=D0=B9=20?=
+  =?UTF-8?q?=D0=9F=D0=BE=D0=BB=D1=8C=D0=B7=D0=BE=D0=B2=D0=B0?=
+  =?UTF-8?q?=D1=82=D0=B5=D0=BB=D1=8C?= <random-user@example.com>
+To: anna.smith@example.com
+Subject: Please fill out the registration form
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+
+Hello. I'm sending you the link to the form that you need to fill =
+to complete the registration process.
+
+http://example.com/form
+
+Please make sure to fill the form before it expires. You only have =
+24 hours!

--- a/src/crystal-mime.cr
+++ b/src/crystal-mime.cr
@@ -5,7 +5,7 @@ require "./rfc2047"
 
 # `MIME` Provides raw email parsing capabilities
 module MIME
-  VERSION = "0.1.17"
+  VERSION = "0.1.18"
 
   struct Email
     property from
@@ -48,7 +48,7 @@ module MIME
       elsif line.blank?
         break
       else
-        k, v = line.split(": ", 2)
+        k, v = line.split(":", 2).map &.strip
         last_key = k
 
         # Patch up subject (from =?UTF-8?q?Yo_=F0=9F=90=95?= => 🦂)
@@ -71,7 +71,7 @@ module MIME
         when "quoted-printable"
           # RFC2045 Section 6.7 (Quoted Printable or quoted-printable).
           # See also: https://www.hjp.at/doc/rfc/rfc1521.html
-          final_content = QuotedPrintable.decode_string(content)
+          final_content = self.decode_quoted_printable(content)
         when "base64"
           final_content = Base64.decode_string(content)
         else
@@ -123,7 +123,7 @@ module MIME
           when "quoted-printable"
             # RFC2045 Section 6.7 (Quoted Printable or quoted-printable).
             # See also: https://www.hjp.at/doc/rfc/rfc1521.html
-            parts[content_type] = QuotedPrintable.decode_string(content)
+            parts[content_type] = self.decode_quoted_printable(content)
           when "base64"
             parts[content_type] = Base64.decode_string(content)
           else
@@ -136,7 +136,7 @@ module MIME
       content_transfer_encoding = headers["Content-Transfer-Encoding"]?
       case content_transfer_encoding
       when "quoted-printable"
-        body = QuotedPrintable.decode_string(body)
+        body = self.decode_quoted_printable(body)
       when "base64"
         body = Base64.decode_string(body)
       end
@@ -190,5 +190,22 @@ module MIME
     else
       nil
     end
+  end
+
+  # Since quoted-printable library we're using has a bug (it crashes at the line
+  # that ends with "=\n" because it only expects "=\r\n") let's make
+  # a workaround here
+  def self.decode_quoted_printable(input : String) : String
+    remaining = input
+    output = ""
+    while remaining.presence
+      line, separator, remaining = remaining.partition("\n")
+      if line.ends_with?("=")
+        output += QuotedPrintable.decode_string(line[...-1])
+      else
+        output += QuotedPrintable.decode_string(line) + "\n"
+      end
+    end
+    output
   end
 end


### PR DESCRIPTION
Because of the bug in underlying library quoted-printable body crashes the parser, because the library only expects `=\r\n` and not `=\n`.

In addition fixed a crash when the header name and the header value are placed on different lines